### PR TITLE
chore: add .gitattribute file

### DIFF
--- a/Pets/.gitattributes
+++ b/Pets/.gitattributes
@@ -1,0 +1,2 @@
+*.pbxproj merge=union
+


### PR DESCRIPTION
## Summary
add `.gitattribute` file to fix `project.pbxproj` conflict problem

